### PR TITLE
CI: build wheels + sdist with cibuildwheel for PyPI

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -33,11 +33,12 @@ jobs:
         include:
           - { os: ubuntu-latest,    label: "linux-x86_64" }
           - { os: ubuntu-24.04-arm, label: "linux-aarch64" }
-          # macOS is arm64-only: the Intel runner (macos-13) is being retired,
-          # and eltopo's Fortran BLAS/LAPACK can't be cross-compiled to x86_64
-          # (Homebrew's gfortran only targets the host arch). Intel-Mac users
-          # install from the sdist.
-          - { os: macos-14, label: "macos-arm64", target: "11.0" }
+          # Build each macOS arch natively (eltopo's Fortran BLAS/LAPACK can't be
+          # cross-compiled: Homebrew's gfortran only targets the host arch).
+          # macos-13 (Intel) is retiring Dec 2025; macos-15-intel is its
+          # supported x86_64 successor (available through ~Fall 2027).
+          - { os: macos-15-intel, label: "macos-x86_64", target: "10.15" }
+          - { os: macos-14,       label: "macos-arm64",  target: "11.0" }
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -33,14 +33,19 @@ jobs:
         include:
           - { os: ubuntu-latest,    label: "linux-x86_64" }
           - { os: ubuntu-24.04-arm, label: "linux-aarch64" }
-          - { os: macos-13,         label: "macos-x86_64",  target: "10.15" }
-          - { os: macos-14,         label: "macos-arm64",   target: "11.0" }
+          # Intel macOS runners (macos-13) are being retired, so build both
+          # macOS architectures on the arm64 runner: arm64 natively (and tested)
+          # and x86_64 via cross-compilation (built but not import-tested, since
+          # x86_64 binaries can't run on the arm64 runner).
+          - { os: macos-14, label: "macos", archs: "x86_64 arm64", target: "11.0" }
     steps:
       - uses: actions/checkout@v4
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.23.4
         env:
+          # empty on linux -> cibuildwheel builds the native host architecture
+          CIBW_ARCHS: ${{ matrix.archs }}
           MACOSX_DEPLOYMENT_TARGET: ${{ matrix.target }}
           # Full CPython matrix only for releases/tags/manual runs; on PRs and
           # ordinary pushes build a single version for fast feedback (each wheel

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -33,11 +33,11 @@ jobs:
         include:
           - { os: ubuntu-latest,    label: "linux-x86_64" }
           - { os: ubuntu-24.04-arm, label: "linux-aarch64" }
-          # Intel macOS runners (macos-13) are being retired, so build both
-          # macOS architectures on the arm64 runner: arm64 natively (and tested)
-          # and x86_64 via cross-compilation (built but not import-tested, since
-          # x86_64 binaries can't run on the arm64 runner).
-          - { os: macos-14, label: "macos", archs: "x86_64 arm64", target: "11.0" }
+          # macOS is arm64-only: the Intel runner (macos-13) is being retired,
+          # and eltopo's Fortran BLAS/LAPACK can't be cross-compiled to x86_64
+          # (Homebrew's gfortran only targets the host arch). Intel-Mac users
+          # install from the sdist.
+          - { os: macos-14, label: "macos-arm64", target: "11.0" }
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,0 +1,87 @@
+name: Wheels
+
+# Build redistributable wheels (and an sdist) with cibuildwheel, and optionally
+# publish them to PyPI when a GitHub Release is published.
+#
+# Notes:
+#  * The C++ build fetches all dependencies (libigl, CGAL, Eigen, eltopo,
+#    collisiondetection, MeshFix, reference BLAS/LAPACK, nanobind), so each wheel
+#    is a full from-source build and takes several minutes.
+#  * Windows is not built: eltopo links a Fortran BLAS/LAPACK, for which there is
+#    no turn-key CI toolchain (see pyproject's [tool.cibuildwheel]).
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+  pull_request:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  build_wheels:
+    name: Wheels ${{ matrix.label }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { os: ubuntu-latest,    label: "linux-x86_64" }
+          - { os: ubuntu-24.04-arm, label: "linux-aarch64" }
+          - { os: macos-13,         label: "macos-x86_64",  target: "10.15" }
+          - { os: macos-14,         label: "macos-arm64",   target: "11.0" }
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.23.4
+        env:
+          MACOSX_DEPLOYMENT_TARGET: ${{ matrix.target }}
+          # Full CPython matrix only for releases/tags/manual runs; on PRs and
+          # ordinary pushes build a single version for fast feedback (each wheel
+          # is a full from-source build of all dependencies).
+          CIBW_BUILD: >-
+            ${{ (github.event_name == 'release'
+                 || github.event_name == 'workflow_dispatch'
+                 || startsWith(github.ref, 'refs/tags/'))
+                && '' || 'cp312-*' }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.label }}
+          path: ./wheelhouse/*.whl
+
+  make_sdist:
+    name: Source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build sdist
+        run: pipx run build --sdist
+      - uses: actions/upload-artifact@v4
+        with:
+          name: sdist
+          path: dist/*.tar.gz
+
+  upload_pypi:
+    name: Publish to PyPI
+    needs: [build_wheels, make_sdist]
+    runs-on: ubuntu-latest
+    # Only publish on a published GitHub Release.
+    if: github.event_name == 'release' && github.event.action == 'published'
+    environment:
+      name: pypi
+      url: https://pypi.org/p/nested_cages
+    permissions:
+      id-token: write  # trusted publishing (OIDC) — no API token needed
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -44,8 +44,8 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.23.4
         env:
-          # empty on linux -> cibuildwheel builds the native host architecture
-          CIBW_ARCHS: ${{ matrix.archs }}
+          # linux entries omit matrix.archs -> "auto" (native host architecture)
+          CIBW_ARCHS: ${{ matrix.archs || 'auto' }}
           MACOSX_DEPLOYMENT_TARGET: ${{ matrix.target }}
           # Full CPython matrix only for releases/tags/manual runs; on PRs and
           # ordinary pushes build a single version for fast feedback (each wheel

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -82,7 +82,7 @@ jobs:
     if: github.event_name == 'release' && github.event.action == 'published'
     environment:
       name: pypi
-      url: https://pypi.org/p/nested_cages
+      url: https://pypi.org/p/nested-cages
     permissions:
       id-token: write  # trusted publishing (OIDC) — no API token needed
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,9 @@ list(REMOVE_ITEM ELTOPO_SRCFILES "${ELTOPO_DIR}/eltopo3d/meshrenderer.cpp")
 add_library(eltopo STATIC ${ELTOPO_SRCFILES})
 target_compile_definitions(eltopo PUBLIC
   -D__LITTLE_ENDIAN__ -DUSE_FORTRAN_BLAS -DNO_GUI -DGRID_100 -DEXTRA_PASSES -DREMOVE_RIZ)
+# This legacy code was written assuming a signed `char` (the x86 default); force
+# it so behavior/compilation matches on platforms where char is unsigned (arm64).
+target_compile_options(eltopo PRIVATE -fsigned-char)
 # eltopo uses #include <myfile.h> instead of #include "myfile.h"
 target_include_directories(eltopo PUBLIC
   "${ELTOPO_DIR}/common/"
@@ -143,6 +146,7 @@ set(COLLISIONDETECTION_DIR "${collisiondetection_SOURCE_DIR}")
 file(GLOB COLLISIONDETECTION_SRCFILES "${COLLISIONDETECTION_DIR}/src/*.cpp")
 add_library(collisiondetection STATIC ${COLLISIONDETECTION_SRCFILES})
 target_include_directories(collisiondetection PUBLIC "${COLLISIONDETECTION_DIR}/include")
+target_compile_options(collisiondetection PRIVATE -fsigned-char)  # see eltopo note above
 target_link_libraries(collisiondetection PUBLIC igl::core)
 
 # ---------------------------------------------------------------------------
@@ -158,9 +162,12 @@ if(WITH_MESHFIX)
                   -P "${CMAKE_CURRENT_SOURCE_DIR}/cmake/patch_meshfix.cmake")
   FetchContent_MakeAvailable(meshfix)
   if(TARGET MeshFix)
-    # MeshFix is old C/C++ that relies on type punning; -fno-strict-aliasing
-    # keeps modern GCC from miscompiling it (segfaults at -O3 otherwise).
-    target_compile_options(MeshFix PRIVATE -fno-strict-aliasing)
+    # MeshFix is old C/C++ that relies on type punning and a signed `char`:
+    #  -fno-strict-aliasing keeps modern GCC from miscompiling it (segfaults at
+    #   -O3 otherwise);
+    #  -fsigned-char fixes a `-1`->char narrowing error where char is unsigned
+    #   (arm64), matching the x86 assumption the code was written under.
+    target_compile_options(MeshFix PRIVATE -fno-strict-aliasing -fsigned-char)
   endif()
 endif()
 

--- a/README.md
+++ b/README.md
@@ -114,15 +114,18 @@ produce identical cages.
 
 `.github/workflows/wheels.yml` builds redistributable wheels with
 [cibuildwheel](https://cibuildwheel.pypa.io) for Linux (`x86_64`, `aarch64`) and
-macOS (`arm64`), CPython 3.8–3.13, plus an sdist. It runs the full matrix on
-tags/releases/manual dispatch and a single-version smoke build on pushes and
-PRs.
+macOS (`x86_64`, `arm64`), CPython 3.8–3.13, plus an sdist. It runs the full
+matrix on tags/releases/manual dispatch and a single-version smoke build on
+pushes and PRs. Each macOS arch is built natively (`macos-15-intel` for x86_64,
+`macos-14` for arm64), because eltopo's Fortran BLAS/LAPACK cannot be
+cross-compiled (Homebrew's `gfortran` only targets the host arch).
 
-Not built (these platforms install from the sdist): **Windows**, and
-**Intel macOS** (`x86_64`). Both come down to eltopo's Fortran BLAS/LAPACK:
-Windows has no turn-key Fortran-BLAS CI toolchain, and Intel-macOS wheels can no
-longer be produced in CI now that GitHub is retiring the Intel runners (and
-`gfortran` cannot cross-compile from the arm64 runners).
+Note: Apple has retired the Intel architecture, and GitHub will drop macOS
+`x86_64` runners after `macos-15-intel` is retired (~Fall 2027); at that point
+Intel-Mac users would install from the sdist.
+
+**Windows** is not built (eltopo links a Fortran BLAS/LAPACK, for which there is
+no turn-key CI toolchain); Windows users install from the sdist.
 
 Publishing to PyPI happens automatically when a GitHub Release is *published*,
 via [trusted publishing](https://docs.pypi.org/trusted-publishers/) (OIDC, no

--- a/README.md
+++ b/README.md
@@ -110,6 +110,21 @@ cages = nested_cages.nested_cages(
 See `tests/regression.py` for a check that the Python bindings and the CLI
 produce identical cages.
 
+### Wheels / publishing to PyPI
+
+`.github/workflows/wheels.yml` builds redistributable wheels with
+[cibuildwheel](https://cibuildwheel.pypa.io) for Linux (`x86_64`, `aarch64`) and
+macOS (`x86_64`, `arm64`), CPython 3.8–3.13, plus an sdist. It runs the full
+matrix on tags/releases/manual dispatch and a single-version smoke build on
+pushes and PRs. (Windows is not built: eltopo links a Fortran BLAS/LAPACK, for
+which there is no turn-key CI toolchain.)
+
+Publishing to PyPI happens automatically when a GitHub Release is *published*,
+via [trusted publishing](https://docs.pypi.org/trusted-publishers/) (OIDC, no
+API token). To enable it once: on PyPI, add a trusted publisher for this project
+pointing at `alecjacobson/nested_cages`, workflow `wheels.yml`, environment
+`pypi`.
+
 
 ## Example usages
 

--- a/README.md
+++ b/README.md
@@ -114,10 +114,15 @@ produce identical cages.
 
 `.github/workflows/wheels.yml` builds redistributable wheels with
 [cibuildwheel](https://cibuildwheel.pypa.io) for Linux (`x86_64`, `aarch64`) and
-macOS (`x86_64`, `arm64`), CPython 3.8–3.13, plus an sdist. It runs the full
-matrix on tags/releases/manual dispatch and a single-version smoke build on
-pushes and PRs. (Windows is not built: eltopo links a Fortran BLAS/LAPACK, for
-which there is no turn-key CI toolchain.)
+macOS (`arm64`), CPython 3.8–3.13, plus an sdist. It runs the full matrix on
+tags/releases/manual dispatch and a single-version smoke build on pushes and
+PRs.
+
+Not built (these platforms install from the sdist): **Windows**, and
+**Intel macOS** (`x86_64`). Both come down to eltopo's Fortran BLAS/LAPACK:
+Windows has no turn-key Fortran-BLAS CI toolchain, and Intel-macOS wheels can no
+longer be produced in CI now that GitHub is retiring the Intel runners (and
+`gfortran` cannot cross-compile from the arm64 runners).
 
 Publishing to PyPI happens automatically when a GitHub Release is *published*,
 via [trusted publishing](https://docs.pypi.org/trusted-publishers/) (OIDC, no

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,9 +24,35 @@ Source = "https://github.com/alecjacobson/nested_cages"
 minimum-version = "0.10"
 build-dir = "build/{wheel_tag}"
 # The bindings are installed into the `nested_cages` package by the CMake
-# install() rules in python/CMakeLists.txt.
-sdist.include = ["python", "*.cpp", "*.h", "CMakeLists.txt", "cmake"]
+# install() rules in python/CMakeLists.txt. scikit-build-core includes all
+# git-tracked files in the sdist by default, which already covers the sources,
+# CMakeLists.txt, python/ and cmake/. Keep the sdist lean by dropping the large
+# example meshes and paper sources, which are not needed to build the wheel.
+sdist.exclude = ["*.off", "TeX", "*.pdf"]
 
 [tool.scikit-build.cmake.define]
 NESTED_CAGES_BUILD_PYTHON = "ON"
 NESTED_CAGES_BUILD_CLI = "OFF"
+
+# ---------------------------------------------------------------------------
+# cibuildwheel: build redistributable wheels in CI (see
+# .github/workflows/wheels.yml). Windows is intentionally not built: eltopo
+# links a Fortran BLAS/LAPACK, for which there is no turn-key CI toolchain.
+# ---------------------------------------------------------------------------
+[tool.cibuildwheel]
+build-frontend = "build"
+# PyPy lacks the heavy C++ toolchain story; musllinux/32-bit lack easy
+# gfortran + Boost; Windows lacks a Fortran BLAS toolchain.
+skip = ["pp*", "*-musllinux*", "*_i686", "*-win32", "*-win_amd64"]
+build-verbosity = 1
+test-command = "python -c \"import nested_cages; assert hasattr(nested_cages, 'nested_cages')\""
+
+[tool.cibuildwheel.linux]
+# manylinux_2_28 ships a recent GCC (with gfortran) and boost-devel in its repos.
+manylinux-x86_64-image = "manylinux_2_28"
+manylinux-aarch64-image = "manylinux_2_28"
+before-all = "dnf install -y gcc-gfortran boost-devel || yum install -y gcc-gfortran boost-devel"
+
+[tool.cibuildwheel.macos]
+# Homebrew's gcc provides gfortran; boost provides the CGAL headers' dependency.
+before-all = "brew install gcc boost"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,8 @@ requires = ["scikit-build-core>=0.10", "nanobind>=2.7"]
 build-backend = "scikit_build_core.build"
 
 [project]
-name = "nested_cages"
+# Distribution name on PyPI (hyphen). The importable package is `nested_cages`.
+name = "nested-cages"
 version = "0.1.0"
 description = "Nested, non-self-intersecting cages for triangle meshes (Sacht et al. 2015)"
 readme = "README.md"


### PR DESCRIPTION
## Summary

Adds continuous integration to build redistributable **wheels** and an **sdist**, and to publish to **PyPI** — so `pip install nested_cages` can Just Work without a from-source build.

Builds on the modernized, FetchContent-based build from #8.

## What's included

- **`.github/workflows/wheels.yml`** — [cibuildwheel](https://cibuildwheel.pypa.io) matrix:
  - Linux `x86_64` (ubuntu-latest) and `aarch64` (native `ubuntu-24.04-arm` runner)
  - macOS `x86_64` (macos-13) and `arm64` (macos-14)
  - CPython **3.8–3.13**, plus a source distribution.
  - **Full matrix** on tags / published releases / manual `workflow_dispatch`; a **single-version smoke build** (cp312) on pushes and PRs, since each wheel is a full from-source build of all dependencies (several minutes each).
- **`[tool.cibuildwheel]` in `pyproject.toml`** — installs the only non-fetchable prerequisites in `before-all`:
  - manylinux_2_28: `dnf/yum install gcc-gfortran boost-devel`
  - macOS: `brew install gcc boost`
  - skips PyPy, musllinux, 32-bit, and Windows; import-tests every wheel.
- **PyPI publish** on a *published* GitHub Release via [trusted publishing](https://docs.pypi.org/trusted-publishers/) (OIDC, no API token), gated on the `pypi` environment.

## Windows

Not built: eltopo links a Fortran BLAS/LAPACK, and there's no turn-key Fortran-BLAS toolchain for Windows CI. Documented in the workflow and README. (Linux/macOS are the platforms the project already claims support for.)

## sdist fix

The initial packaging used recursive `sdist.include` globs (`*.h`, `*.cpp`) that pulled the **entire local `build/` tree** — including the Boost that libigl's CGAL fetches — into the tarball (**51 MB**). Now the sdist relies on git-tracked files and excludes the large example meshes: **~54 KB**, containing exactly the sources + `CMakeLists.txt` + `cmake/` + `python/` + `pyproject.toml`.

## One-time setup required

To enable auto-publish, add a PyPI **trusted publisher** for this project pointing at `alecjacobson/nested_cages`, workflow `wheels.yml`, environment `pypi`. (Or swap the last step for an API-token upload.)

## Validation done locally

- `cibuildwheel --print-build-identifiers` confirms the intended matrix (cp38–cp313 × manylinux/macOS; musllinux/i686/win/pypy skipped).
- Workflow YAML parses; jobs = build_wheels, make_sdist, upload_pypi.
- `python -m build --sdist` produces the lean 54 KB sdist with no `build/`/`.off` leakage.
- (The equivalent from-source build was already verified end-to-end in #8, incl. `pip install` from a git URL.)

The actual cross-platform wheel builds need a live Actions run (no Docker/macOS available locally); the macOS Fortran discovery and manylinux `before-all` are the most likely spots to need a tweak on first run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)